### PR TITLE
Fix warnings about ignoring fdreopen()'s result.

### DIFF
--- a/plf_colony_test_suite.cpp
+++ b/plf_colony_test_suite.cpp
@@ -219,7 +219,8 @@ unsigned int xor_rand()
 
 int main()
 {
-	freopen("error.log","w", stderr); // For catching assertion failure info when run outside of a command line prompt
+	if (!freopen("error.log","w", stderr)) // For catching assertion failure info when run outside of a command line prompt
+		return fprintf(stderr, "Can't redirect to error.log: %s\n", strerror(errno)), 1;
 
 	using namespace std;
 	using namespace plf;


### PR DESCRIPTION
```
g++ -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -Wl,-z,relro -Wl,-z,now -o testsuite plf_colony_test_suite.cpp
plf_colony_test_suite.cpp: In function 'int main()':
plf_colony_test_suite.cpp:222:9: warning: ignoring return value of 'FILE* freopen(const char*, const char*, FILE*)', declared with attribute warn_unused_result [-Wunused-result]
  freopen("error.log","w", stderr); // For catching assertion failure info when run outside of a command line prompt
  ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
```

While such errors are unlikely to actually matter, let's at least silence the warning.