### PR TITLE
Added link to the central repository of build2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 An unordered data container providing fast iteration/insertion/erasure while maintaining pointer/iterator/reference validity to non-erased elements.
 
  - A conan package for colony is available here: https://github.com/alaingalvan/conan-plf-colony
- - A build2 package for colony is available here: https://github.com/build2-packaging/plf-colony
+ - A `build2` package for colony is available here:
+    - The central repository provides some versions of the `plf-colony` package: https://cppget.org/plf-colony
+    - Sources of the packages (can be used when you want a version that isn't published in the central repository) : https://github.com/build2-packaging/plf-colony
 
 plf::colony is C++98/03/11/14/17/20-compatible.


### PR DESCRIPTION
Most users will get the package from the central repository.

The git repository if more useful when you need to use a version which is not already published in the central repository.