### PR TITLE
Feat/add module

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,30 @@ Documentation and function descriptions here: https://plflib.org/colony.htm#func
 
  - A conan package for colony is available here: https://conan.io/center/plf_colony
  - A build2 package for colony is available here: https://cppget.org/plf-colony
+ - Easy integration with CPM: 
+ ```
+set(PLF_COLONY_VERSION <INSERT>)
+cpmaddpackage(URI "gh:mattreecebentley/plf_colony#${PLF_COLONY_VERSION}" DOWNLOAD_ONLY ON)
+
+if(plf_colony_ADDED)
+  add_library(plf_colony INTERFACE)
+  target_sources(plf_colony PUBLIC FILE_SET HEADERS 
+    BASE_DIRS ${plf_colony_SOURCE_DIR} FILES ${plf_colony_SOURCE_DIR}/plf_colony.h)
+  add_library(plf::colony ALIAS plf_colony)
+endif()
+```
+ - Even as a C++20 module:
+```
+set(PLF_COLONY_VERSION <INSERT>)
+cpmaddpackage(URI "gh:mattreecebentley/plf_colony#${PLF_COLONY_VERSION}" DOWNLOAD_ONLY ON)
+
+if(plf_colony_ADDED)
+  add_library(plf_colony)
+  target_sources(plf_colony PUBLIC FILE_SET CXX_MODULES 
+      BASE_DIRS ${plf_colony_SOURCE_DIR} FILES ${plf_colony_SOURCE_DIR}/plf_colony.cpp)
+  add_library(plf::colony ALIAS plf_colony)
+endif()
+```
 
 plf::colony is C++98/03/11/14/17/20/23-compatible.
 

--- a/plf_colony.cpp
+++ b/plf_colony.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2025, Matthew Bentley (mattreecebentley@gmail.com) www.plflib.org
+
+// zLib license (https://www.zlib.net/zlib_license.html):
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+// 	claim that you wrote the original software. If you use this software
+// 	in a product, an acknowledgement in the product documentation would be
+// 	appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+// 	misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+
+module;
+#include "plf_colony.h"
+export module plf.colony;
+export namespace plf {
+using plf::colony;
+using plf::limits;
+using plf::performance;
+using plf::priority;
+using plf::ranges::from_range_t;
+}  // namespace plf

--- a/plf_colony.h
+++ b/plf_colony.h
@@ -265,7 +265,7 @@
 			namespace ranges
 			{
 				struct from_range_t {};
-				constexpr from_range_t from_range;
+				inline constexpr from_range_t from_range;
 			}
 		#endif
 	}
@@ -338,7 +338,7 @@ namespace plf
 
 	// To enable conversion to void * when allocator supplies non-raw pointers:
 	template <class source_pointer_type>
-	static PLF_CONSTFUNC void * void_cast(const source_pointer_type source_pointer) PLF_NOEXCEPT
+	inline PLF_CONSTFUNC void * void_cast(const source_pointer_type source_pointer) PLF_NOEXCEPT
 	{
 		#ifdef PLF_CPP20_SUPPORT
 			return static_cast<void *>(std::to_address(source_pointer));
@@ -350,7 +350,7 @@ namespace plf
 
 	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
 		template <class iterator_type>
-		static PLF_CONSTFUNC std::move_iterator<iterator_type> make_move_iterator(iterator_type it)
+		inline PLF_CONSTFUNC std::move_iterator<iterator_type> make_move_iterator(iterator_type it)
 		{
 			return std::move_iterator<iterator_type>(std::move(it));
 		}

--- a/plf_colony.h
+++ b/plf_colony.h
@@ -75,6 +75,11 @@
 		#define PLF_CONSTFUNC constexpr
 	#endif
 #elif defined(__cplusplus) && __cplusplus >= 201103L // C++11 support, at least
+  #if __cplusplus >= 202002L  // to be able to use _LIBCPP_VERSION and __GLIBCXX__ below
+  	#include <version>
+  #else
+  	#include <ciso646>
+  #endif
 	#if defined(__GNUC__) && defined(__GNUC_MINOR__) && !defined(__clang__) // If compiler is GCC/G++
 		#if (__GNUC__ == 4 && __GNUC_MINOR__ >= 3) || __GNUC__ > 4
 			#define PLF_MOVE_SEMANTICS_SUPPORT


### PR DESCRIPTION
This adds minor changes to build plf_colony as a C++20 module. I tested it with gcc-14/15 and clang-20. Clang was happy even before these changes. Only gcc-15 detected linkage issues. To resolve those I followed the same approach that I saw here: https://github.com/nlohmann/json/issues/4759

Additionally the c++ library detection failed for me. I have to include at least one std header to for those tests to work. This becomes notable when using the library as a C++ module.